### PR TITLE
fix: improve error handling and return values in git operations

### DIFF
--- a/diffweave/cli.py
+++ b/diffweave/cli.py
@@ -61,7 +61,7 @@ def commit(model: Annotated[str, typer.Option(help="Internal Databricks model to
         try:
             run_cmd(f"git commit -m {shlex.quote(msg)}")
         except SystemError:
-            console.print(f"Uh oh, something happened while committing. Trying again!")
+            console.print("Uh oh, something happened while committing. Trying again!")
             repo.add_files(current_repo)
             run_cmd(f"git commit -m {shlex.quote(msg)}")
 

--- a/diffweave/cli.py
+++ b/diffweave/cli.py
@@ -58,14 +58,19 @@ def commit(model: Annotated[str, typer.Option(help="Internal Databricks model to
 
     try:
         msg = llm.iterate_on_commit_message(repo_status_prompt, context)
-        run_cmd(f"git commit -m {shlex.quote(msg)}")
+        try:
+            run_cmd(f"git commit -m {shlex.quote(msg)}")
+        except SystemError:
+            console.print(f"Uh oh, something happened while committing. Trying again!")
+            repo.add_files(current_repo)
+            run_cmd(f"git commit -m {shlex.quote(msg)}")
 
         console.print(rich.text.Text(r"Push? <enter>/y for yes, anything else for no", style="yellow"))
         should_push = console.input(r"> ").strip().lower()
         if should_push in ["", "y", "yes"]:
-            push_result = run_cmd("git push")
+            push_result, error = run_cmd("git push")
 
-            if "http" in push_result:
+            if "http" in push_result + error:
                 open_pr = (
                     console.input(r"Open Pull Request (PR)? <enter>/y for yes, anything else for no:\n> ")
                     .strip()

--- a/diffweave/prompt.txt
+++ b/diffweave/prompt.txt
@@ -19,13 +19,11 @@ convention dovetails with SemVer, by describing the features, fixes, and breakin
 
 The commit message should be structured as follows:
 
-```
 <type>[optional scope]: <description>
 
 [optional body]
 
 [optional footer(s)]
-```
 
 The commit contains the following structural elements, to communicate intent to the consumers of your library:
 
@@ -68,44 +66,29 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ## Examples
 
-Here are some examples of valid commit messages (wrapped here in backticks for clarity, however your responses MUST NOT include backticks):
-
-Commit message with description and breaking change footer
-```
+### Commit message with description and breaking change footer
 feat: allow provided config object to extend other configs
 
 BREAKING CHANGE: `extends` key in config file is now used for extending other config files
-```
 
-Commit message with ! to draw attention to breaking change
-```
+### Commit message with ! to draw attention to breaking change
 feat!: send an email to the customer when a product is shipped
-```
 
-Commit message with scope and ! to draw attention to breaking change
-```
+### Commit message with scope and ! to draw attention to breaking change
 feat(api)!: send an email to the customer when a product is shipped
-```
 
-Commit message with both ! and BREAKING CHANGE footer
-```
+### Commit message with both ! and BREAKING CHANGE footer
 chore!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
-```
 
-Commit message with no body
-```
+### Commit message with no body
 docs: correct spelling of CHANGELOG
-```
 
-Commit message with scope
-```
+### Commit message with scope
 feat(lang): add Polish language
-```
 
-Commit message with multi-paragraph body and multiple footers
-```
+### Commit message with multi-paragraph body and multiple footers
 fix: prevent racing of requests
 
 Introduce a request id and a reference to latest request. Dismiss
@@ -116,4 +99,3 @@ obsolete now.
 
 Reviewed-by: Z
 Refs: #123
-```

--- a/diffweave/utils.py
+++ b/diffweave/utils.py
@@ -1,6 +1,4 @@
-import sys
 import subprocess
-from typing import Union
 
 import rich
 import rich.panel
@@ -11,7 +9,7 @@ import rich.text
 import rich.padding
 
 
-def run_cmd(cmd: str, show_output: bool = True, silent: bool = False, **subprocess_kwargs) -> Union[None, str]:
+def run_cmd(cmd: str, show_output: bool = True, silent: bool = False, **subprocess_kwargs) -> tuple[None | str, None | str]:
     """
     Execute a shell command and handle its output.
 
@@ -65,4 +63,4 @@ def run_cmd(cmd: str, show_output: bool = True, silent: bool = False, **subproce
             rich.padding.Padding(rich.text.Text("result truncated", style="lightgrey"), (0, 0, 0, 2), style="dim")
         )
 
-    return output
+    return output, error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     {name="Zoë Farmer", email="zfarmer@squareup.com"},
     {name="Chase Hudson", email="chasehudson@squareup.com"},
 ]
-version = "1.0.1"
+version = "1.0.2"
 description = "Assists with git workflows using LLMs."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -4,7 +4,8 @@ import diffweave
 
 
 def test_running_commands():
-    assert len(diffweave.run_cmd("find .").splitlines()) > 1
+    stdout, stderr = diffweave.run_cmd("find .")
+    assert len(stdout.splitlines()) > 1
 
 
 def test_bad_command():
@@ -14,4 +15,5 @@ def test_bad_command():
 
 def test_piping():
     content = "foo bar biz baz"
-    assert content == diffweave.run_cmd("cat", input=content)
+    stdout, stderr = diffweave.run_cmd("cat", input=content)
+    assert content == stdout


### PR DESCRIPTION
- Update `run_cmd` to return tuple of (stdout, stderr) instead of just stdout
- Add retry logic for git commit failures with automatic file re-staging
- Check both stdout and stderr for HTTP URLs when detecting push output for PR creation
- Remove unused imports (sys, Union) from utils module
- Update type hints to use modern Python syntax (tuple[None | str, None | str])
- Clean up prompt.txt formatting by removing unnecessary code block markers
- Update all test cases to handle new tuple return value from run_cmd