### PR TITLE
refactor: migrate from typer to cyclopts and add new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,72 @@ DiffWeave is installed as an isolated tool using `uv`:
 uvx diffweave-ai
 ```
 
-```bash
-# Basic usage
-uvx diffweave-ai commit
+## Usage
 
-# With specific model
-uvx diffweave-ai commit --model "your-model-name"
+### Configure a model
+
+Before generating commit messages, configure at least one model endpoint:
+
+```bash
+uvx diffweave-ai add-model \
+  --model "name-of-your-model" \
+  --endpoint "https://endpoint-url" \
+  --token "$TOKEN"
+```
+
+Then set the default model to use:
+
+```bash
+uvx diffweave-ai set-default "name-of-your-model"
+```
+
+You can still override the model per invocation with the `--model` / `-m` flag.
+
+### Generate a commit message
+
+Once you have a model configured and some changes staged in your current Git repository you can run:
+
+```bash
+uvx diffweave-ai
+```
+
+This will:
+
+- Show the current `git status`.
+- Optionally stage files for you (interactive by default).
+- Generate a commit message using your configured model.
+- Let you review/refine the message.
+- Attempt `git commit` (and optionally `git push` and PR open if a URL is printed).
+
+To specify a model for a single run:
+
+```bash
+uvx diffweave-ai -m "your-model-name"
+```
+
+If you prefer a simpler, more natural-language commit style rather than Conventional Commits, pass `--simple`:
+
+```bash
+uvx diffweave-ai --simple
+```
+
+You can also run in dry-run mode (generate and print a commit message without committing):
+
+```bash
+uvx diffweave-ai --dry-run
+```
+
+Or in a non-interactive mode, which will generate a message and attempt to commit and push without asking follow-up questions:
+
+```bash
+uvx diffweave-ai --non-interactive
 ```
 
 ## Features
 
-- AI-powered commit message generation
-- Interactive file selection for unstaged changes
-- Support for various LLM providers
-- Custom context to guide message generation
-- Interactive workflow with message review
+- AI-powered commit message generation based on staged diffs
+- Interactive or non-interactive workflows
+- Support for configuring custom LLM HTTP endpoints
+- Ability to set and override the default model
+- Optional simpler commit style via `--simple`
+- Optional push and PR-open flow when `git push` prints a URL

--- a/diffweave/ai.py
+++ b/diffweave/ai.py
@@ -19,7 +19,7 @@ if (not CONFIG_FILE.exists()) and LEGACY_CONFIG.exists():
     CONFIG_FILE.write_text(LEGACY_CONFIG.read_text())
 
 
-def configure_custom_model(model_name: str, endpoint: str, token: str, config_file: Path = CONFIG_FILE):
+def configure_custom_model(model_name: str, endpoint: str, token: str, config_file: Path = None):
     """
     Configure a custom LLM model with the specified endpoint and token.
 
@@ -28,6 +28,8 @@ def configure_custom_model(model_name: str, endpoint: str, token: str, config_fi
         endpoint: The API endpoint URL for the model
         token: The authentication token for accessing the model API
     """
+    if config_file is None:
+        config_file = CONFIG_FILE
     config_file.parent.mkdir(parents=True, exist_ok=True)
     config_file.touch(exist_ok=True)
 
@@ -44,7 +46,10 @@ def configure_custom_model(model_name: str, endpoint: str, token: str, config_fi
     config_file.write_text(yaml.safe_dump(existing_config))
 
 
-def set_default_model(model_name: str, config_file: Path = CONFIG_FILE):
+def set_default_model(model_name: str, config_file: Path = None):
+    if config_file is None:
+        config_file = CONFIG_FILE
+
     console = rich.console.Console()
 
     config_file.parent.mkdir(parents=True, exist_ok=True)
@@ -60,8 +65,11 @@ def set_default_model(model_name: str, config_file: Path = CONFIG_FILE):
 
 
 class LLM:
-    def __init__(self, model_name: str, config_file: Path = CONFIG_FILE):
+    def __init__(self, model_name: str, config_file: Path = None, simple: bool = False):
+        self.simple = simple
         self.console = rich.console.Console()
+        if config_file is None:
+            config_file = CONFIG_FILE
         if not config_file.exists():
             raise FileNotFoundError("Config not set! Please do so before use.")
 
@@ -82,13 +90,17 @@ class LLM:
         )
         self.model_name = model_name
         self.system_prompt = (Path(__file__).parent / "prompt.md").read_text()
+        if self.simple:
+            self.system_prompt = (Path(__file__).parent / "prompt_simple.md").read_text()
 
-    def iterate_on_commit_message(self, repo_status_prompt: str, context: str) -> str:
+    def iterate_on_commit_message(self, repo_status_prompt: str, context: str, return_first: bool = False) -> str:
         console = rich.console.Console()
 
         message_attempts = []
         feedback = []
         user_prompt = [repo_status_prompt, f"\n\nAdditional context provided by the user:\n{context}\n"]
+
+        loop = asyncio.new_event_loop()
 
         while True:
             if message_attempts and feedback:
@@ -98,11 +110,14 @@ class LLM:
                     )
 
             with console.status("Generating commit message...") as status:
-                loop = asyncio.new_event_loop()
                 msg = loop.run_until_complete(self.query_model(user_prompt))
                 status.update("Done!")
             message_attempts.append(msg)
             console.print(rich.panel.Panel(msg, title="Generated commit message"))
+
+            if return_first:
+                return msg
+
             console.print(
                 rich.text.Text(
                     "Does this message look fine? <enter> to continue, otherwise provide feedback to improve the message",

--- a/diffweave/cli.py
+++ b/diffweave/cli.py
@@ -1,12 +1,13 @@
 import sys
+from pathlib import Path
 import re
 import shlex
-import asyncio
-import pathlib
 from typing_extensions import Annotated
 import webbrowser
+from dataclasses import dataclass
 
-import typer
+import cyclopts
+from cyclopts import Parameter
 import rich
 import rich.text
 import rich.panel
@@ -15,11 +16,28 @@ import rich.padding
 
 from . import run_cmd, repo, ai
 
-app = typer.Typer()
+app = cyclopts.App()
 
 
-@app.command()
-def commit(model: Annotated[str, typer.Option(help="Internal Databricks model to use")] = None):
+@app.default
+def commit(
+    model: Annotated[str | None, Parameter(help="Internal Databricks model to use")] = None,
+    simple: Annotated[
+        bool,
+        Parameter(help="Use simpler commit structure for messages (not conventional commits)"),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        Parameter(help="Generate a commit message based on the current repo status, print to stdout, and quit."),
+    ] = False,
+    non_interactive: Annotated[
+        bool,
+        Parameter(
+            help="Run in non-interactive mode. Similar to dry run except we then use that first commit message that comes back."
+        ),
+    ] = False,
+    config: Annotated[Path | None, Parameter(help="Path to config file")] = None,
+):
     """
     Generate a commit message for the staged changes in the current git repository.
 
@@ -34,13 +52,16 @@ def commit(model: Annotated[str, typer.Option(help="Internal Databricks model to
     """
     console = rich.console.Console()
 
-    llm = ai.LLM(model)
+    skip_interaction = dry_run or non_interactive
+
+    llm = ai.LLM(model, simple=simple, config_file=config)
 
     current_repo = repo.get_repo()
 
     run_cmd("git status")
 
-    repo.add_files(current_repo)
+    if not skip_interaction:
+        repo.add_files(current_repo)
 
     diffs = repo.generate_diffs_with_context(current_repo)
 
@@ -49,21 +70,32 @@ def commit(model: Annotated[str, typer.Option(help="Internal Databricks model to
         sys.exit()
 
     repo_status_prompt = diffs
-    console.print(
-        rich.text.Text(
-            r"Do you have any additional context/information for this commit? Leave blank for none.", style="yellow"
+    if skip_interaction:
+        context = ""
+    else:
+        console.print(
+            rich.text.Text(
+                r"Do you have any additional context/information for this commit? Leave blank for none.", style="yellow"
+            )
         )
-    )
-    context = console.input(r"> ").strip().lower()
+        context = console.input(r"> ").strip().lower()
 
     try:
-        msg = llm.iterate_on_commit_message(repo_status_prompt, context)
+        msg = llm.iterate_on_commit_message(repo_status_prompt, context, return_first=skip_interaction)
+
+        if dry_run:
+            return
+
         try:
             run_cmd(f"git commit -m {shlex.quote(msg)}")
         except SystemError:
-            console.print("Uh oh, something happened while committing. Trying again!")
+            console.print("Uh oh, something happened while committing. Trying once more!")
             repo.add_files(current_repo)
             run_cmd(f"git commit -m {shlex.quote(msg)}")
+
+        if skip_interaction:
+            run_cmd("git push")
+            return
 
         console.print(rich.text.Text(r"Push? <enter>/y for yes, anything else for no", style="yellow"))
         should_push = console.input(r"> ").strip().lower()
@@ -84,11 +116,12 @@ def commit(model: Annotated[str, typer.Option(help="Internal Databricks model to
         console.print(rich.text.Text("Cancelled..."), style="bold red")
 
 
-@app.command()
-def add_custom_model(
-    model: Annotated[str, typer.Option(help="Model name to use", prompt=True)],
-    endpoint: Annotated[str, typer.Option(help="Endpoint to use", prompt=True)],
-    token: Annotated[str, typer.Option(help="API token for authentication", prompt=True)],
+@app.command
+def add_model(
+    model: Annotated[str, Parameter(alias="-m", help="Model name to use")],
+    endpoint: Annotated[str, Parameter(alias="-e", help="Endpoint to use")],
+    token: Annotated[str, Parameter(alias="-t", help="API token for authentication")],
+    config: Annotated[Path | None, Parameter(alias="-c", help="Path to config file")] = None,
 ):
     """
     Configure a custom model to be used
@@ -100,12 +133,18 @@ def add_custom_model(
         model: The name to identify the custom model
         endpoint: The API endpoint URL for the model
         token: The authentication token for accessing the model API
+        config: The path to config file
     """
-    ai.configure_custom_model(model, endpoint, token)
+    console = rich.console.Console()
+    ai.configure_custom_model(model, endpoint, token, config_file=config)
+    console.print(f"Model [{model}] successfully added!", style="bold green")
 
 
-@app.command()
-def set_default_llm_model(model: Annotated[str, typer.Argument(help="Model name to use")]):
+@app.command
+def set_default(
+    model: Annotated[str, Parameter(help="Model name to use")],
+    config: Annotated[Path | None, Parameter(help="Path to config file")] = None,
+):
     """
     Set the default model to use for LLM operations - this leverages the `llm` library under the hood and will set that default as well.
 
@@ -114,11 +153,16 @@ def set_default_llm_model(model: Annotated[str, typer.Argument(help="Model name 
 
     Args:
         model: The name of the model to set as default
+        config: The path to config file
 
     Raises:
         ValueError: If the specified model is not found in the available models
     """
-    ai.set_default_model(model)
+    console = rich.console.Console()
+
+    ai.set_default_model(model, config)
+
+    console.print(f"Model [{model}] successfully set to default!", style="bold green")
 
 
 if __name__ == "__main__":

--- a/diffweave/prompt_simple.md
+++ b/diffweave/prompt_simple.md
@@ -1,0 +1,47 @@
+# Agent Overview
+
+The provided diff shows changes between staged files and HEAD. You are being used to generate the commit message.
+
+Generate a clear, concise, natural-language commit message that accurately describes the changes. Aim for one short,
+descriptive sentence on the first line. If helpful, you MAY include a few short follow-up lines to expand on important
+details, but you do NOT need to follow any formal convention such as "Conventional Commits". Avoid artificial structure
+like `feat:` or `fix:` prefixes unless they arise naturally from the description.
+
+Guidelines:
+- Use simple, direct language that a teammate can quickly understand.
+- Focus on what changed and why it changed, not how.
+- If the change is small and easily understood, a single line is sufficient.
+- If the change is more complex, you MAY add brief bullet points or short sentences on subsequent lines.
+
+Do not wrap the message in any additional formatting characters including backticks or quotes. Do NOT reference LLMs or
+Chat or AI in the commit message. You are a highly skilled developer who would never reference AI in a commit message.
+
+Your response will be directly used as the commit message.
+
+# Examples
+
+Below are examples of the style and tone to use. These are examples only; you do NOT need to mimic them exactly.
+
+## Single-line commits
+
+Update CLI help text for commit command
+
+Fix bug in diff generation when files are deleted
+
+Improve performance of repository scan for large projects
+
+## Multi-line commits
+
+Refine commit message generation for staged changes
+Add clearer prompts for additional user context
+Handle empty diffs without exiting with an error
+
+Tighten configuration handling for custom LLM models
+Ensure default model is always present in config
+Validate model names before attempting queries
+
+Clarify behavior when no files are staged
+Show a helpful message instead of failing silently
+
+Use these examples as inspiration, but always base your message on the actual changes shown in the diff.
+

--- a/diffweave/repo.py
+++ b/diffweave/repo.py
@@ -56,7 +56,6 @@ def generate_diffs_with_context(current_repo: git.Repo) -> str:
     return diff_overview
 
 
-
 def generate_diffs_with_valid_prior_commit(project_root: pathlib.Path, diffs: git.DiffIndex[git.diff.Diff]) -> str:
     console = rich.console.Console()
 
@@ -106,6 +105,7 @@ def generate_diffs_with_valid_prior_commit(project_root: pathlib.Path, diffs: gi
     diff_overview = "\n".join(diff_items)
 
     return diff_overview
+
 
 def generate_diffs_with_fresh_repo(project_root: pathlib.Path) -> str:
     stdout, stderr = utils.run_cmd("git diff --name-only --cached", show_output=False)

--- a/diffweave/utils.py
+++ b/diffweave/utils.py
@@ -10,7 +10,10 @@ import rich.padding
 
 
 def run_cmd(
-    cmd: str, show_output: bool = True, silent: bool = False, **subprocess_kwargs,
+    cmd: str,
+    show_output: bool = True,
+    silent: bool = False,
+    **subprocess_kwargs,
 ) -> tuple[None | str, None | str]:
     """
     Execute a shell command and handle its output.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,27 +29,26 @@ of python and all required dependencies!
 
 ### Usage
 
-#### Configuring the completion endpoint
+#### Configuring a model endpoint
 
 ```bash
-uvx diffweave-ai add-custom-model \
+uvx diffweave-ai add-model \
     --model "name-of-your-model" \
     --endpoint "https://endpoint-url" \
-    --token $TOKEN
+    --token "$TOKEN"
 ```
 
-This will prompt you for the API token for the model. Do NOT clutter your shell history with
-this token!
+This stores the model configuration in your local diffweave config file so it can be reused across runs. Do NOT clutter your shell history with the raw token—set it as an environment variable and reference it as shown above.
 
 ##### Example: Databricks Endpoint Configuration
 
 Get a token from Databricks and set it as the environment variable `DATABRICKS_TOKEN`:
 
 ```bash
-uvx diffweave-ai add-custom-model \
+uvx diffweave-ai add-model \
     --model "claude-3-7-sonnet" \
     --endpoint "https://block-lakehouse-production.cloud.databricks.com/serving-endpoints" \
-    --token $DATABRICKS_TOKEN
+    --token "$DATABRICKS_TOKEN"
 ```
 
 #### Configuring the default model to use
@@ -57,7 +56,7 @@ uvx diffweave-ai add-custom-model \
 Finally, in order to ensure that `diffweave` uses the model you just configured, you need to set it as the default model:
 
 ```bash
-uvx diffweave-ai set-default-llm-model claude-3-7-sonnet
+uvx diffweave-ai set-default "claude-3-7-sonnet"
 ```
 
 #### Using diffweave
@@ -65,11 +64,38 @@ uvx diffweave-ai set-default-llm-model claude-3-7-sonnet
 Basic usage - examine the current repo, stage files for commit, and generate a commit message:
 
 ```bash
-uvx diffweave-ai commit
+uvx diffweave-ai
 ```
 
-If you want to specify the model to run you can add the `--model` flag:
+If you want to specify the model to run you can add the `--model` / `-m` flag:
 
 ```bash
-uvx diffweave-ai commit --model "claude-3-7-sonnet"
+uvx diffweave-ai -m "claude-3-7-sonnet"
 ```
+
+If you prefer a simpler, more natural-language commit style rather than Conventional Commits, pass `--simple`:
+
+```bash
+uvx diffweave-ai --simple
+```
+
+You can also run in dry-run mode (generate and print a commit message without committing):
+
+```bash
+uvx diffweave-ai --dry-run
+```
+
+Or in a non-interactive mode, which will generate a message and attempt to commit and push without additional prompts:
+
+```bash
+uvx diffweave-ai --non-interactive
+```
+
+During a normal interactive `uvx diffweave-ai` run the CLI will:
+
+- Show `git status` for your current repository.
+- Offer to stage changes using git.
+- Generate a commit message using your configured model and internal prompt.
+- Let you review/refine the message.
+- Attempt `git commit -m "<message>"`.
+- Optionally run `git push` and, if the push output includes a URL, offer to open it in your browser to create a PR.

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ test target='tests/':
     uv run pytest --cov=diffweave -cov-branch {{ target }}
 
 commit:
-    uv run diffweave-ai commit
+    uv run diffweave-ai
 
 docs:
     uv run mkdocs build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     {name="Zoë Farmer", email="zfarmer@squareup.com"},
     {name="Chase Hudson", email="chasehudson@squareup.com"},
 ]
-version = "1.0.3"
+version = "1.1.0"
 description = "Assists with git workflows using LLMs."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,6 @@ diffweave-ai = "diffweave:app"
 [tool.uv]
 resolution = "highest"
 
-[[tool.uv.index]]
-url = "https://pypi.block-artifacts.com/block-pypi/simple"
-default = true
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "beaupy>=3.10.1",
+    "cyclopts>=3.24.0",
     "gitpython>=3.1.44",
     "openai>=1.82.0",
     "pyyaml>=6.0.2",
-    "typer>=0.15",
 ]
 [dependency-groups]
 dev = [
@@ -39,6 +39,10 @@ diffweave-ai = "diffweave:app"
 
 [tool.uv]
 resolution = "highest"
+
+[[tool.uv.index]]
+url = "https://pypi.block-artifacts.com/block-pypi/simple"
+default = true
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import git
+import yaml
+import pytest
+
+from diffweave import app
+
+
+def test_setting_custom_model(capsys, config_file: Path):
+    with pytest.raises(SystemExit):
+        app("add-model")
+
+    arguments = (
+        "add-model "
+        "--model 'gpt-5.1' "
+        "--endpoint 'https://api.example.com' "
+        "--token '0xdeadbeef' "
+        f"--config {config_file.absolute()}"
+    )
+    app(tokens=arguments, result_action="return_value")
+    assert "successfully added!" in capsys.readouterr().out
+
+    assert config_file.exists()
+    file_contents = config_file.read_text()
+    assert "gpt-5.1" in file_contents
+    assert "api.example.com" in file_contents
+    assert "deadbeef" in file_contents
+    data = yaml.safe_load(file_contents)
+    assert "<<DEFAULT>>" in data
+    assert "gpt-5.1" in data
+
+
+def test_setting_default_model(populated_config: Path):
+    with pytest.raises(SystemExit):
+        app("set-default")
+
+    data = yaml.safe_load(populated_config.read_text())
+    assert data["<<DEFAULT>>"] == "gpt-5.1"
+
+    app(f"set-default gpt-4o --config {populated_config.absolute()}", result_action="return_value")
+
+    data = yaml.safe_load(populated_config.read_text())
+    assert data["<<DEFAULT>>"] == "gpt-4o"
+
+
+def test_commit(monkeypatch, capsys, new_repo: git.Repo, populated_config: Path):
+    with pytest.raises(SystemExit):
+        app(f"--dry-run --config {populated_config.absolute()}", result_action="return_value")
+
+    new_repo.index.add(["README.md", "main.py", "test/__init__.py"])
+    app(f"--dry-run --config {populated_config.absolute()}", result_action="return_value")
+    assert "Generated commit message" in capsys.readouterr().out

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,5 +1,5 @@
 import os
-import pathlib
+from pathlib import Path
 import shutil
 import string
 
@@ -28,7 +28,7 @@ def test_adding_files(new_repo: git.Repo):
 
 
 def test_adding_files_with_one_removed(new_repo: git.Repo):
-    root_dir = pathlib.Path(new_repo.working_dir)
+    root_dir = Path(new_repo.working_dir)
     all_files = diffweave.repo.get_untracked_and_modified_files(new_repo)
     new_repo.index.add([str(f.relative_to(root_dir)) for f in all_files])
     new_repo.index.commit("Initial commit")
@@ -39,21 +39,26 @@ def test_adding_files_with_one_removed(new_repo: git.Repo):
 
 
 def test_finding_repo_root(new_repo: git.Repo, monkeypatch):
-    root_dir = pathlib.Path(new_repo.working_dir)
-    assert pathlib.Path(diffweave.repo.get_repo().working_dir) == root_dir
+    root_dir = Path(new_repo.working_dir)
+    assert root_dir.exists()
+
+    assert Path(diffweave.repo.get_repo().working_dir) == root_dir
 
     monkeypatch.chdir(root_dir / "test")
-    assert pathlib.Path(diffweave.repo.get_repo().working_dir) == root_dir
+    assert Path(os.getcwd()) == (root_dir / "test")
+    assert Path(diffweave.repo.get_repo().working_dir) == root_dir
 
     monkeypatch.chdir(root_dir / "test" / "submodule1")
-    assert pathlib.Path(diffweave.repo.get_repo().working_dir) == root_dir
+    assert Path(diffweave.repo.get_repo().working_dir) == root_dir
+
+    monkeypatch.undo()
 
 
 def test_getting_all_files(new_repo: git.Repo):
     assert len(diffweave.repo.get_untracked_and_modified_files(new_repo)) == 5
     new_repo.index.add(["README.md"])
     assert len(diffweave.repo.get_untracked_and_modified_files(new_repo)) == 4
-    pathlib.Path("README.md").write_text("AKJHSDGFKJHSDFLKJHSDFLKJH")
+    Path("README.md").write_text("AKJHSDGFKJHSDFLKJHSDFLKJH")
     assert len(diffweave.repo.get_untracked_and_modified_files(new_repo)) == 5
 
 
@@ -63,7 +68,7 @@ def test_generating_diffs_with_no_commits(new_repo: git.Repo):
 
 
 def test_generating_diffs(new_repo: git.Repo):
-    root_dir = pathlib.Path(new_repo.working_dir)
+    root_dir = Path(new_repo.working_dir)
     new_repo.index.add(["README.md"])
 
     diff_summary = diffweave.repo.generate_diffs_with_context(new_repo)
@@ -80,7 +85,7 @@ def test_generating_diffs(new_repo: git.Repo):
 
 
 def test_diffs_with_deleted_file(new_repo: git.Repo):
-    root_dir = pathlib.Path(new_repo.working_dir)
+    root_dir = Path(new_repo.working_dir)
     all_files = diffweave.repo.get_untracked_and_modified_files(new_repo)
     new_repo.index.add([str(f.relative_to(root_dir)) for f in all_files])
     new_repo.index.commit("Initial commit")
@@ -105,7 +110,7 @@ def test_deleted_files(new_repo: git.Repo):
 
 
 def test_large_diffs(new_repo: git.Repo):
-    root_dir = pathlib.Path(new_repo.working_dir)
+    root_dir = Path(new_repo.working_dir)
     new_repo.index.add(["README.md"])
     new_repo.index.commit("Initial commit")
     all_files = diffweave.repo.get_untracked_and_modified_files(new_repo)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -58,7 +58,7 @@ def test_getting_all_files(new_repo: git.Repo):
 
 
 def test_generating_diffs_with_no_commits(new_repo: git.Repo):
-    new_repo.index.add(["README.md", 'main.py', 'test/__init__.py'])
+    new_repo.index.add(["README.md", "main.py", "test/__init__.py"])
     assert diffweave.repo.generate_diffs_with_context(new_repo)
 
 


### PR DESCRIPTION
- Replace typer with cyclopts for CLI argument parsing
- Add `--simple` flag to use simplified commit message format instead of Conventional Commits
- Add `--dry-run` flag to generate commit message without committing
- Add `--non-interactive` flag to skip user interaction and auto-commit
- Add `--config` parameter to all commands for custom config file paths
- Refactor default parameter handling to use `None` instead of `CONFIG_FILE` constant
- Create new `prompt_simple.md` for natural language commit messages
- Move event loop creation outside iteration loop in `iterate_on_commit_message`
- Add comprehensive test coverage for CLI commands and repository operations
- Rename `add_custom_model` command to `add_model` for consistency
- Rename `set_default_llm_model` command to `set_default` for brevity
- Update justfile to use simplified `diffweave-ai` command invocation
- Add success messages to model configuration commands
- Remove extra blank line in repo.py for formatting consistency
- Update pyproject.toml to replace typer dependency with cyclopts