### PR TITLE
chore: update project dependencies and version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,6 @@ diffweave-ai = "diffweave:app"
 [tool.uv]
 resolution = "highest"
 
-[[tool.uv.index]]
-url = "https://pypi.block-artifacts.com/block-pypi/simple"
-default = true
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     {name="Zoë Farmer", email="zfarmer@squareup.com"},
     {name="Chase Hudson", email="chasehudson@squareup.com"},
 ]
-version = "2.0.0"
+version = "2.0.1"
 description = "Assists with git workflows using LLMs."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -14,6 +14,7 @@ dependencies = [
     "cyclopts>=3.24.0",
     "gitpython>=3.1.44",
     "openai>=1.82.0",
+    "python-dateutil>=2.9.0.post0",
     "pyyaml>=6.0.2",
 ]
 [dependency-groups]
@@ -40,6 +41,10 @@ diffweave-ai = "diffweave:app"
 
 [tool.uv]
 resolution = "highest"
+
+[[tool.uv.index]]
+url = "https://pypi.block-artifacts.com/block-pypi/simple"
+default = true
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
- Updated the project version from 2.0.0 to 2.0.1.
- Added `python-dateutil>=2.9.0.post0` to project dependencies.
- Added a new index `[tool.uv.index]` with URL set to `https://pypi.block-artifacts.com/block-pypi/simple` as default in `tool.uv`.