### PR TITLE
fix: correct README title and improve Databricks token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DiffWeave AI
+# DiffWeave
 
 DiffWeave is a tool that automatically generates meaningful Git commit messages and pull request descriptions using large language models (LLMs). It analyzes your staged changes and creates descriptive commit messages, saving you time and ensuring consistent documentation.
 

--- a/diffweave/ai.py
+++ b/diffweave/ai.py
@@ -2,7 +2,6 @@ import sys
 import asyncio
 from pathlib import Path
 import json
-import datetime
 import subprocess
 
 import openai
@@ -11,7 +10,6 @@ import rich.console
 import rich.text
 import rich.panel
 import yaml
-import dateutil.parser
 
 CONFIG_BASEDIR = Path().home() / ".config"
 CONFIG_DIRECTORY = CONFIG_BASEDIR / "diffweave"
@@ -86,9 +84,14 @@ class LLM:
             case {"type": "databricks"}:
                 account = model_config["account"]
                 host = f"https://{account}.cloud.databricks.com"
-                if (token := load_databricks_token_from_cache(account)) is None:
-                    subprocess.run(f'databricks auth login --profile {account} --host {host}', shell=True)
-                    token = load_databricks_token_from_cache(account)
+                if (token := load_databricks_token(account)) is None:
+                    subprocess.run(["databricks", "auth", "login", "--profile", account, "--host", host])
+                    token = load_databricks_token(account)
+                    if token is None:
+                        self.console.print(
+                            f"[red]Failed to acquire Databricks token for profile {account!r}.[/red]"
+                        )
+                        raise EnvironmentError
 
                 self.client = openai.OpenAI(
                     base_url="https://block-lakehouse-production.cloud.databricks.com/serving-endpoints",
@@ -191,18 +194,21 @@ def _initialize_config():
     return CONFIG_FILE
 
 
-def load_databricks_token_from_cache(account: str) -> str | None:
-    homedir = Path().home()
-    databricks_config_dir = homedir / '.databricks'
-    token_cache = databricks_config_dir / 'token-cache.json'
+def load_databricks_token(account: str) -> str | None:
+    """Fetch a fresh Databricks access token via the CLI.
+
+    Databricks CLI v1.0.0 moved token storage to the OS keychain, so reading
+    ``~/.databricks/token-cache.json`` directly no longer works. ``databricks
+    auth token`` handles refresh transparently and returns the live token.
+    """
+    result = subprocess.run(
+        ["databricks", "auth", "token", "--profile", account, "-o", "json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
     try:
-        conf = json.loads(token_cache.read_text())
-        token_conf = conf['tokens'][account]
-        expires = dateutil.parser.parse(token_conf['expiry'])
-        tzinfo = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
-        now = datetime.datetime.now(tz=tzinfo)
-        is_token_expired = expires < now
-        if not is_token_expired:
-            return token_conf['access_token']
-    except Exception as e:
-        rich.console.Console().print(f"[yellow]Could not load cached Databricks token:[/yellow] {e}")
+        return json.loads(result.stdout)["access_token"]
+    except (json.JSONDecodeError, KeyError):
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     {name="Zoë Farmer", email="zfarmer@squareup.com"},
     {name="Chase Hudson", email="chasehudson@squareup.com"},
 ]
-version = "2.0.0"
+version = "2.0.1"
 description = "Assists with git workflows using LLMs."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -111,14 +111,14 @@ def databricks_config(monkeypatch, config_file):
 
 
 def test_llm_init_databricks_cached_token(databricks_config, mocker):
-    mocker.patch("diffweave.ai.load_databricks_token_from_cache", return_value="cached-token")
+    mocker.patch("diffweave.ai.load_databricks_token", return_value="cached-token")
     llm = diffweave.ai.LLM()
     assert llm.model_name == "databricks-llama"
 
 
 def test_llm_init_databricks_triggers_login(databricks_config, mocker):
     mocker.patch(
-        "diffweave.ai.load_databricks_token_from_cache",
+        "diffweave.ai.load_databricks_token",
         side_effect=[None, "new-token"],
     )
     mock_subprocess = mocker.patch("subprocess.run")
@@ -163,43 +163,22 @@ def test_iterate_no_panel(fake_config, mocker, capsys):
     assert "Generated PR description" in capsys.readouterr().out
 
 
-def test_load_databricks_token_valid(monkeypatch, tmp_path):
-    cache_dir = tmp_path / ".databricks"
-    cache_dir.mkdir()
-    future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
-    token_data = {
-        "tokens": {
-            "my-account": {
-                "access_token": "secret-token",
-                "expiry": future.isoformat(),
-            }
-        }
-    }
-    (cache_dir / "token-cache.json").write_text(json.dumps(token_data))
-    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: tmp_path))
-    result = diffweave.ai.load_databricks_token_from_cache("my-account")
-    assert result == "secret-token"
+def test_load_databricks_token_success(mocker):
+    mocker.patch(
+        "subprocess.run",
+        return_value=mocker.Mock(
+            returncode=0,
+            stdout=json.dumps({"access_token": "secret-token", "token_type": "Bearer"}),
+        ),
+    )
+    assert diffweave.ai.load_databricks_token("my-account") == "secret-token"
 
 
-def test_load_databricks_token_expired(monkeypatch, tmp_path):
-    cache_dir = tmp_path / ".databricks"
-    cache_dir.mkdir()
-    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
-    token_data = {
-        "tokens": {
-            "my-account": {
-                "access_token": "secret-token",
-                "expiry": past.isoformat(),
-            }
-        }
-    }
-    (cache_dir / "token-cache.json").write_text(json.dumps(token_data))
-    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: tmp_path))
-    result = diffweave.ai.load_databricks_token_from_cache("my-account")
-    assert result is None
+def test_load_databricks_token_cli_failure(mocker):
+    mocker.patch("subprocess.run", return_value=mocker.Mock(returncode=1, stdout=""))
+    assert diffweave.ai.load_databricks_token("my-account") is None
 
 
-def test_load_databricks_token_missing_file(monkeypatch, tmp_path):
-    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: tmp_path))
-    result = diffweave.ai.load_databricks_token_from_cache("my-account")
-    assert result is None
+def test_load_databricks_token_malformed_output(mocker):
+    mocker.patch("subprocess.run", return_value=mocker.Mock(returncode=0, stdout="not json"))
+    assert diffweave.ai.load_databricks_token("my-account") is None


### PR DESCRIPTION
- Changed the title of the `README.md` from "DiffWeave AI" to "DiffWeave" for consistency.
- Updated `diffweave/ai.py`:
  - Removed unnecessary imports of `datetime` and `dateutil.parser`.
  - Replaced the custom function for loading Databricks token from cache with a more reliable method using `databricks-cli`.
  - Enhanced error handling to provide clearer feedback if Databricks token cannot be acquired.
- Revised unit tests in `tests/test_ai.py` to align with the new token acquisition approach.
  - Removed old tests related to the cached token method.
  - Added new tests to validate the new token-fetching logic via `databricks-cli`.
- Improved reliability and maintainability by using CLI commands for token management instead of direct file access.